### PR TITLE
Codigo para resolver el almacenamiento de latitud y longitud sobre la base

### DIFF
--- a/lib/models/casos.ts
+++ b/lib/models/casos.ts
@@ -1,16 +1,16 @@
-/** 
+/**
  * Copyright 2020, Ingenia, S.A.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * @author jamartin@ingenia.es
  */
 import { Entity, Column, PrimaryGeneratedColumn, Index, OneToMany, ManyToMany } from 'typeorm'
@@ -40,9 +40,9 @@ export class Casos {
     email: string;
     @Column()
     direccion: string;
-    @Column()
+    @Column({type: "decimal", precision: 3, scale: 10})
     lat: number;
-    @Column()
+    @Column({type: "decimal", precision: 3, scale: 10})
     lng: number;
     @Column()
     observaciones: string;

--- a/lib/models/departamentos.ts
+++ b/lib/models/departamentos.ts
@@ -1,16 +1,16 @@
-/** 
+/**
  * Copyright 2020, Ingenia, S.A.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * @author jamartin@ingenia.es
  */
 import { Entity, Column, PrimaryGeneratedColumn, Index, OneToMany } from 'typeorm'
@@ -24,9 +24,9 @@ export class Departamentos {
     id: number;
     @Column()
     nombre: string;
-    @Column()
+    @Column({type: "decimal", precision: 3, scale: 10})
     lat: number;
-    @Column()
+    @Column({type: "decimal", precision: 3, scale: 10})
     lng: number;
 
     @OneToMany(type => Provincias, provincias => provincias.departamento)

--- a/lib/models/distritos.ts
+++ b/lib/models/distritos.ts
@@ -1,16 +1,16 @@
-/** 
+/**
  * Copyright 2020, Ingenia, S.A.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * @author jamartin@ingenia.es
  */
 import { Entity, Column, PrimaryGeneratedColumn, Index, ManyToOne,JoinColumn } from 'typeorm'
@@ -24,9 +24,9 @@ export class Distritos {
     id: number;
     @Column()
     nombre: string;
-    @Column()
+    @Column({type: "decimal", precision: 3, scale: 10})
     lat: number;
-    @Column()
+    @Column({type: "decimal", precision: 3, scale: 10})
     lng: number;
 
     @ManyToOne(type => Municipios, municipio => municipio.distritos)

--- a/lib/models/municipios.ts
+++ b/lib/models/municipios.ts
@@ -1,16 +1,16 @@
-/** 
+/**
  * Copyright 2020, Ingenia, S.A.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * @author jamartin@ingenia.es
  */
 import { Entity, Column, PrimaryGeneratedColumn, Index, OneToMany, ManyToOne,JoinColumn } from 'typeorm'
@@ -25,9 +25,9 @@ export class Municipios {
     id: number;
     @Column()
     nombre: string;
-    @Column()
+    @Column({type: "decimal", precision: 3, scale: 10})
     lat: number;
-    @Column()
+    @Column({type: "decimal", precision: 3, scale: 10})
     lng: number;
 
     @ManyToOne(type => Provincias, provincia => provincia.municipios)

--- a/lib/models/provincias.ts
+++ b/lib/models/provincias.ts
@@ -1,16 +1,16 @@
-/** 
+/**
  * Copyright 2020, Ingenia, S.A.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * @author jamartin@ingenia.es
  */
 import { Entity, Column, PrimaryGeneratedColumn, Index, OneToMany, ManyToOne, JoinColumn } from 'typeorm'
@@ -25,9 +25,9 @@ export class Provincias {
     id: number;
     @Column()
     nombre: string;
-    @Column()
+    @Column({type: "decimal", precision: 3, scale: 10})
     lat: number;
-    @Column()
+    @Column({type: "decimal", precision: 3, scale: 10})
     lng: number;
 
     @ManyToOne(type => Departamentos, departamentos => departamentos.provincias)

--- a/ormconfig.json
+++ b/ormconfig.json
@@ -1,0 +1,25 @@
+{
+  "type": "postgres",
+  "host": "localhost",
+  "port": 5432,
+  "username": "ecaller",
+  "password": "ecaller",
+  "database": "ecaller",
+  "synchronize": true,
+  "logging": false,
+  "entities": [
+    "lib/models/**/*.ts"
+  ],
+  "migrations": [
+    "lib/migration/**/*.ts"
+  ],
+  "subscribers": [
+    "lib/subscriber/**/*.ts"
+  ],
+  "cli": {
+    "entitiesDir": "dist/models",
+    "migrationsDir": "dist/migration",
+    "subscribersDir": "dist/subscriber"
+  },
+  "migrationsRun": true
+}


### PR DESCRIPTION
Se requiere que los campos en la base se creen como number y no como int al momento de inicializar/sincronizar la base, los atributos en las propiedades logran este cometido