### PR TITLE
Insertar boolean no integer

### DIFF
--- a/scripts/ecaller-epidemias.bbdd.sql
+++ b/scripts/ecaller-epidemias.bbdd.sql
@@ -384,7 +384,7 @@ SELECT pg_catalog.setval('respuestas_id_seq', 51, true);
 
 
 insert into usuarios (id, username, password, nombre, activo, imagen, rol) values 
-(1, 'demo', '$2b$10$53y.tmRZne2VzjsVwQoyqurGpDqg4lezcYNlW0xLtmcQy2SdQBZTO', 'Usuario de demo', 1, null, 'N');
+(1, 'demo', '$2b$10$53y.tmRZne2VzjsVwQoyqurGpDqg4lezcYNlW0xLtmcQy2SdQBZTO', 'Usuario de demo', true, null, 'N');
 
 SELECT pg_catalog.setval('usuarios_id_seq', 1, true);
 


### PR DESCRIPTION
Se produce un error al inicializar la base de datos por insertar un integer en campo boolean:

```code
db_1       | 2020-04-21 11:46:57.745 UTC [75] ERROR:  column "activo" is of type boolean but expression is of type integer at character 179
db_1       | 2020-04-21 11:46:57.745 UTC [75] HINT:  You will need to rewrite or cast the expression.
db_1       | 2020-04-21 11:46:57.745 UTC [75] STATEMENT:  insert into usuarios (id, username, password, nombre, activo, imagen, rol) values 
db_1       |    (1, 'demo', '$2b$10$53y.tmRZne2VzjsVwQoyqurGpDqg4lezcYNlW0xLtmcQy2SdQBZTO', 'Usuario de demo', 1, null, 'N');
db_1       | psql:/docker-entrypoint-initdb.d/ecaller-epidemias.bbdd.sql:387: ERROR:  column "activo" is of type boolean but expression is of type integer
db_1       | LINE 2: ...Dqg4lezcYNlW0xLtmcQy2SdQBZTO', 'Usuario de demo', 1, null, '...
db_1       |                                                              ^
db_1       | HINT:  You will need to rewrite or cast the expression.
```